### PR TITLE
ISSUE-7 added links to most recent haddock and benchmarks

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,8 @@
 language: generic
 sudo: false
+env:
+    global:
+        - secure: "qSKsy0OGJ/GvkD4G9vHO75NZqJbx01sudVZM/A6QORmvKIa05/rdfONkUZNpPIbBWKiDs8LJ3JcWswkbOY+ffo9csdxcrEZAJnJiqiGiwZJXRwITXQneX+IY1w0mMhORg2b8qKVSyRkQ8qXezx78KivLmLl2ViMdpVq34/+jL3RvpJzD8LIyql0/dN2N2pzG4ICAG09XNXlg9LSbLWd9VNKwJjOx7UiTvsTQxiimOOJ/SNWyPM2OT+CuALp8CS85kTUTIyfFPoFdwWHsck1UyJP5Cv7uBYxKtQnF8IgWAZkfrFQptcGnmfFelDvOkWvwJeTQCNH2flwVebnFk/tIt2dR8ae9GP3jL5qWoXmxDofsR9eQS3eKvXdE1Gzx5Gn78gXLyAyWSIduvDEs8VvAyzd/uAcFlqW3zhpx9K2qSq3+KaXaXTk7bmGOc+HNgjvr9LFBl4PtsdAKZOI2EleXm+287pWVVMXE74g8jN/q8UU2MwEqvLymZdTOk8OSeS/oEFcGzUe01YYBr8ibC9b/btEPeLmj42xWiYOcWaDnlZX0EBUkpxqTcMAHIgDZX59AqpUrbUgQyTTQwRINA6H5qCeYIdFdmuFz+MdJ1kdBWWYrd11Pp49T7QMR38U2xaQSNVUFhCHf4SJWZPlUrC7981F/Rf2g+mYeb3trH0EQGM0="
 
 cache:
     directories:
@@ -67,8 +70,12 @@ script:
        hlint test/ --cpp-simple --hint=HLint.hs;
        stack --system-ghc --no-terminal build --pedantic;;
      stack)
-       stack --no-terminal test --haddock --no-haddock-deps --ghc-options="-Werror";;
+       stack --no-terminal test --haddock --no-haddock-deps --ghc-options="-Werror";
+       stack bench --benchmark-arguments "-o benchmarks.html";;
    esac
+
+after_success:
+    - ./build-docs.sh
 
 notifications:
   slack: allanconsulting:nKAH0suU2gwPbWQpNtXNXujR

--- a/README.md
+++ b/README.md
@@ -4,7 +4,12 @@
 The λ-BLAS (lambda-BLAS) project is an attempt to implement the Basic
 Linear Algebra Subroutines (BLAS) library in Haskell.   This work differs
 from previous attempts by providing native Haskell implementations of the
-linear algebra subroutines rather than utilizing the foreign function interface to call a C library.  As a result the exposed linear algebra functions exposed strongly and statically typed, deterministic, thread safe and more likely to benefit from compiler optimization (e.g. stream fusion )
+linear algebra subroutines rather than utilizing the foreign function interface to call a C library.  As a result the exposed linear algebra functions exposed strongly and statically typed, deterministic, thread safe and more likely to benefit from compiler optimization (e.g. stream fusion ) .
+
+The latest haddock documentation and benchmarks can be found at the links below:
+[Documentation]()
+[Benchmarks](https://dlewissandy.github.io/lambda-blas/benchmarks.html)
+[Documentation](https://dlewissandy.github.io/lambda-blas/)
 
 ## Getting Started
 ### Prerequisites

--- a/build-docs.sh
+++ b/build-docs.sh
@@ -1,0 +1,34 @@
+#!/bin/bash
+# The lambda-blas project has a branch (gh-pages) that contains the content for
+# the git hub web pages.   Since this branch contains no source code, only
+# build artifacts, we have chosen to simply overwrite the existing commit
+# each time a new artiact is generated.
+
+# In order to protect the lambda-blas repository from inadvertant changes to
+# The master or feature branches, all work on the gh-pages branch will be
+# performed in a separate folder.
+
+# Create the gh-pages folder and copy the haddock and benchmark artifacts from
+# the latest build
+rm -rf ../gh-pages
+mkdir -p ../gh-pages
+cp -R "$(stack path --local-doc-root)" ../gh-pages
+cp benchmarks.html ../gh-pages
+cd ../gh-pages
+
+# Configure the new folder as a git repository.   Rather than cloning (which)
+# could take a long time, we simply initialize it and set the remote to the
+# lambda-blas remote.   Depending upon if the script is run on the CI machine
+# or locally we may have a couple of different steps.
+git init
+if [ "$TRAVIS" == "true" ]; then
+    git config user.email "travis@travis-ci.org"
+    git config user.name "Travis"
+    git remote add origin https://${GH_TOKEN}@github.com/dlewissandy/lambda-blas.git &> /dev/null
+else
+    git remote add origin git@github.com:dlewissandy/lambda-blas.git
+fi
+git checkout -B gh-pages
+git add .
+git commit -m "Haddocks updated"
+git push --force origin gh-pages &> /dev/null


### PR DESCRIPTION
The build-docs.sh script contains the bash commands to run after the build has completed.   Information regarding the approach that was used can be found at : https://chromabits.com/posts/2016/07/04/haddock-travis/

