### PR TITLE
ISSUE-16 - Added naive sdot function and unit test

### DIFF
--- a/src/Numerical/BLAS/Single.hs
+++ b/src/Numerical/BLAS/Single.hs
@@ -13,7 +13,7 @@ import qualified Data.Vector.Unboxed as V
 sdot_zip :: Vector Float -- ^ The vector u
     -> Vector Float      -- ^ The vector v
     -> Float             -- ^ The dot product u . v
-sdot_zip u v = V.foldr (+) 0 $ V.zipWith (*) u v
+sdot_zip u v = V.foldl (+) 0 $ V.zipWith (*) u v
 
 
 {- | O(n) sdot computes the sum of the products of elements drawn from two


### PR DESCRIPTION
The pre-existing implementation of sdot_zip was right associative, and
therefore produced results that were not byte equivalent to its
specification.   This commit addresses the issue and introduces a unit
test to guard against future regression.