### PR TITLE
ISSUE #6 - Implemented recursive sdot function

### DIFF
--- a/BLAS360.cabal
+++ b/BLAS360.cabal
@@ -42,6 +42,7 @@ library
                        vector
   hs-source-dirs:      src
   default-language:    Haskell2010
+  ghc-options: -Wall -Werror -O2
 
 test-suite blas-test
   hs-source-dirs: test
@@ -53,7 +54,7 @@ test-suite blas-test
 
   frameworks: Accelerate
   extra-libraries: cblas
-  ghc-options: -Wall -Werror -msse2 -O1
+  ghc-options: -Wall -Werror -msse2 -O2
 
 benchmark blas-benchmark
     hs-source-dirs: test
@@ -64,4 +65,4 @@ benchmark blas-benchmark
     type: exitcode-stdio-1.0
     frameworks: Accelerate
     extra-libraries: cblas
-    ghc-options: -msse2 -O1
+    ghc-options: -Wall -Werror -O2

--- a/test/Bench.hs
+++ b/test/Bench.hs
@@ -3,9 +3,8 @@
 -- the BLAS subroutines
 module Main( main ) where
 
-import qualified Data.Vector.Unboxed as V
+import qualified Data.Vector.Storable as V
 import Foreign.Marshal.Array
-import System.Random
 import Test.QuickCheck.Gen
 import Foreign.Ptr
 import Criterion.Main

--- a/test/Gen.hs
+++ b/test/Gen.hs
@@ -32,18 +32,18 @@ module Gen
 
 import System.Random
 import Test.QuickCheck.Gen
-import Data.Vector.Unboxed
+import Data.Vector.Storable
 
 -- | Given a generator for the elements, construct a random vector of length
 -- between 1 and 1000.
-genVector :: (Unbox a) => Gen a -> Gen (Vector a)
+genVector :: (Storable a) => Gen a -> Gen (Vector a)
 genVector gen = do
     n<- choose (1,1000)
     genNVector gen n
 
 -- | Given a generator for the elements, construct a
 -- random vector of the given length
-genNVector :: (Unbox a) => Gen a -> Int -> Gen (Vector a)
+genNVector :: (Storable a) => Gen a -> Int -> Gen (Vector a)
 genNVector gen n = vectorOf n gen >>= return.fromList
 
 -- | Given a random generator for a floating point type, generate a random

--- a/test/Main.hs
+++ b/test/Main.hs
@@ -2,7 +2,7 @@
 -- the native haskell implementations of BLAS subroutines.
 module Main( main ) where
 
-import qualified Data.Vector.Unboxed as V
+import qualified Data.Vector.Storable as V
 import Foreign.Marshal.Array
 import System.Random
 import Test.Tasty


### PR DESCRIPTION
* implemented recursive sdot function using hylomorphisms and manual fusion
  as described on the ticket for issue #6
* Added O2 compiler option (or replaced O1 compiler option) for all
  libraries, test suites and benchmarks to facilitate compiler optimization
  of the sdot function
* Switched from Unboxed to Storable vectors to facilitate O(1) splitting of
  vectors.  This is necessary to achieve the performance target for the
  sdot function.