### PR TITLE
Issue 5 - add linux builds to travis

### DIFF
--- a/.travis-setup.sh
+++ b/.travis-setup.sh
@@ -12,7 +12,7 @@ fetch_stack_osx() {
 }
 
 fetch_stack_linux() {
-  curl -sL https://www.stackage.org/stack/linux-x86_64 | tar xz --wildcards --strip-components=1 -C ~/.local/bin '*/stack';
+  curl -sL https://www.stackage.org/stack/linux-x86_64 | tar xz --wildcards --strip-components=1 -C ~/.local/bin '*/stack'
 }
 
 fetch_blas_osx() {
@@ -45,7 +45,8 @@ cd BLAS-3.7.0
 gfortran -c -O3 *.f               # Compile, but don't link
 if [ `uname` = "Darwin" ]; then
     /Library/Developer/CommandLineTools/usr/bin/ar rcs libblas.a *.o
+    sudo cp libblas.a /usr/local/lib/
 else
-    ar rcs libblas.a *.o on linux     # Create a static library from the object files
+    ar rcs libblas.a *.o      # Create a static library from the object files
+    sudo cp libblas.a /usr/local/lib/  # Install the library for use.
 fi
-sudo cp libblas.a /usr/local/lib  # Install the library for use.

--- a/.travis-setup.sh
+++ b/.travis-setup.sh
@@ -15,26 +15,37 @@ fetch_stack_linux() {
   curl -sL https://www.stackage.org/stack/linux-x86_64 | tar xz --wildcards --strip-components=1 -C ~/.local/bin '*/stack';
 }
 
+fetch_blas_osx() {
+  curl -skL http://www.netlib.org/blas/blas-3.7.0.tgz | tar xz
+}
+
+fetch_blas_linux() {
+  curl -sL http://www.netlib.org/blas/blas-3.7.0.tgz | tar xz
+}
+
 # We need stack to generate cabal files with precise bounds, even for cabal
 # builds.
 mkdir -p ~/.local/bin;
 if [ `uname` = "Darwin" ]; then
   travis_retry fetch_stack_osx
+  travis_retry fetch_blas_osx
+  # INSTALL FORTRAN
+  wget http://coudert.name/software/gfortran-6.1-ElCapitan.dmg
+  hdiutil mount gfortran-6.1-ElCapitan.dmg
+  sudo installer -package /Volumes/gfortran-6.1-ElCapitan/gfortran-6.1-ElCapitan/gfortran.pkg -target "/Volumes/Macintosh HD"
 else
   travis_retry fetch_stack_linux
+  travis_retry fetch_blas_linux
 fi
 
-case "$BUILD" in
-  stack)
-    # However, we only need stack to download GHC for stack builds.
-    travis_retry stack --no-terminal setup;
-    ;;
-  cabal)
-mkdir -p $HOME/.cabal
-cat > $HOME/.cabal/config <<EOF
-remote-repo: hackage.haskell.org:http://hackage.fpcomplete.com/
-remote-repo-cache: $HOME/.cabal/packages
-jobs: \$ncpus
-EOF
-;;
-esac
+travis_retry stack --no-terminal setup;
+# build the blas library and install it so that the haskell code can statically
+# link it later
+cd BLAS-3.7.0
+gfortran -c -O3 *.f               # Compile, but don't link
+if [ `uname` = "Darwin" ]; then
+    /Library/Developer/CommandLineTools/usr/bin/ar rcs libblas.a *.o
+else
+    ar rcs libblas.a *.o on linux     # Create a static library from the object files
+fi
+sudo cp libblas.a /usr/local/lib  # Install the library for use.

--- a/.travis.yml
+++ b/.travis.yml
@@ -13,29 +13,13 @@ cache:
 matrix:
   fast_finish: true
   exclude:
-    - env: BUILD=cabal CABALVER=1.24 GHCVER=7.8.4 STACK_YAML=stack-7.8.yaml
-      compiler: ": #GHC 7.8.4"
-      addons: {apt: {packages: [cabal-install-1.24,ghc-7.8.4], sources: [hvr-ghc]}}
-
-    - env: BUILD=cabal CABALVER=1.22 GHCVER=7.10.3
-      compiler: ": #GHC 7.10.3"
-      addons: {apt: {packages: [cabal-install-1.22,ghc-7.10.3], sources: [hvr-ghc]}}
-
-    - env: BUILD=cabal CABALVER=1.24 GHCVER=8.0.1
-      compiler: ": #GHC 8.0.1"
-      addons: {apt: {packages: [cabal-install-1.24,ghc-8.0.1], sources: [hvr-ghc]}}
-
     - env: BUILD=stack GHCVER=7.8.4 STACK_YAML=stack-7.8.yaml
       compiler: ": #stack 7.8.4"
-      addons: {apt: {packages: [ghc-7.8.4], sources: [hvr-ghc]}}
+      addons: {apt: {packages: [ghc-7.8.4,gfortran], sources: [hvr-ghc]}}
 
     - env: BUILD=stack GHCVER=8.0.1 STACK_YAML=stack-8.0.yaml
       compiler: ": #stack 8.0.1"
-      addons: {apt: {packages: [ghc-8.0.1], sources: [hvr-ghc]}}
-
-    - env: BUILD=style GHCVER=8.0.1 STACK_YAML=stack-8.0.yaml
-      compiler: ": #stack 8.0.1"
-      addons: {apt: {packages: [ghc-8.0.1], sources: [hvr-ghc]}}
+      addons: {apt: {packages: [ghc-8.0.1,gfortran], sources: [hvr-ghc]}}
 
   include:
     - env: BUILD=stack STACK_YAML=stack.yaml
@@ -45,34 +29,16 @@ matrix:
 before_install:
  - rvm get head # workarround for travis issue https://github.com/travis-ci/travis-ci/issues/6307
  - unset CC
- - case "$BUILD" in
-     style)
-       export PATH=$HOME/.local/bin:/opt/ghc/$GHCVER/bin:$PATH;;
-     stack)
-       export PATH=$HOME/.local/bin:/opt/ghc/$GHCVER/bin:$PATH;;
-   esac
+ - export PATH=$HOME/.local/bin:/opt/ghc/$GHCVER/bin:$PATH
  - ./.travis-setup.sh
 
 install:
  - echo "$(ghc --version) [$(ghc --print-project-git-commit-id 2> /dev/null || echo '?')]"
- - case "$BUILD" in
-     style)
-       stack --system-ghc --no-terminal install hlint;;
-     stack)
-       stack --no-terminal test --only-dependencies;;
-   esac
+ - stack --no-terminal test --only-dependencies
 
 script:
- - set -e; case "$BUILD" in
-     style)
-       hlint src/ --hint=HLint.hs;
-       hlint src/ --cpp-define=WINDOWS=1 --hint=HLint.hs;
-       hlint test/ --cpp-simple --hint=HLint.hs;
-       stack --system-ghc --no-terminal build --pedantic;;
-     stack)
-       stack --no-terminal test --haddock --no-haddock-deps --ghc-options="-Werror";
-       stack bench --benchmark-arguments "-o benchmarks.html";;
-   esac
+ - set -e
+ - stack --no-terminal test --haddock --no-haddock-deps --ghc-options="-Werror"
 
 after_success:
     - ./build-docs.sh

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,5 @@
 language: generic
-sudo: false
+sudo: required
 env:
     global:
         - secure: "qSKsy0OGJ/GvkD4G9vHO75NZqJbx01sudVZM/A6QORmvKIa05/rdfONkUZNpPIbBWKiDs8LJ3JcWswkbOY+ffo9csdxcrEZAJnJiqiGiwZJXRwITXQneX+IY1w0mMhORg2b8qKVSyRkQ8qXezx78KivLmLl2ViMdpVq34/+jL3RvpJzD8LIyql0/dN2N2pzG4ICAG09XNXlg9LSbLWd9VNKwJjOx7UiTvsTQxiimOOJ/SNWyPM2OT+CuALp8CS85kTUTIyfFPoFdwWHsck1UyJP5Cv7uBYxKtQnF8IgWAZkfrFQptcGnmfFelDvOkWvwJeTQCNH2flwVebnFk/tIt2dR8ae9GP3jL5qWoXmxDofsR9eQS3eKvXdE1Gzx5Gn78gXLyAyWSIduvDEs8VvAyzd/uAcFlqW3zhpx9K2qSq3+KaXaXTk7bmGOc+HNgjvr9LFBl4PtsdAKZOI2EleXm+287pWVVMXE74g8jN/q8UU2MwEqvLymZdTOk8OSeS/oEFcGzUe01YYBr8ibC9b/btEPeLmj42xWiYOcWaDnlZX0EBUkpxqTcMAHIgDZX59AqpUrbUgQyTTQwRINA6H5qCeYIdFdmuFz+MdJ1kdBWWYrd11Pp49T7QMR38U2xaQSNVUFhCHf4SJWZPlUrC7981F/Rf2g+mYeb3trH0EQGM0="
@@ -12,16 +12,11 @@ cache:
 
 matrix:
   fast_finish: true
-  exclude:
-    - env: BUILD=stack GHCVER=7.8.4 STACK_YAML=stack-7.8.yaml
-      compiler: ": #stack 7.8.4"
-      addons: {apt: {packages: [ghc-7.8.4,gfortran], sources: [hvr-ghc]}}
-
-    - env: BUILD=stack GHCVER=8.0.1 STACK_YAML=stack-8.0.yaml
-      compiler: ": #stack 8.0.1"
-      addons: {apt: {packages: [ghc-8.0.1,gfortran], sources: [hvr-ghc]}}
-
   include:
+    - env: BUILD=stack GHCVER=7.10.3 STACK_YAML=stack.yaml
+      compiler: ": #stack 7.10.3"
+      addons: {apt: {packages: [ghc-7.10.3,gfortran], sources: [hvr-ghc]}}
+
     - env: BUILD=stack STACK_YAML=stack.yaml
       compiler: ": #stack 7.10.3 osx"
       os: osx

--- a/BLAS360.cabal
+++ b/BLAS360.cabal
@@ -52,8 +52,7 @@ test-suite blas-test
       random, tasty-quickcheck, BLAS360
   type: exitcode-stdio-1.0
 
-  frameworks: Accelerate
-  extra-libraries: cblas
+  extra-libraries: blas
   ghc-options: -Wall -Werror -msse2 -O2
 
 benchmark blas-benchmark
@@ -63,6 +62,5 @@ benchmark blas-benchmark
     build-depends:    base, primitive, vector, QuickCheck,
         random, criterion, BLAS360
     type: exitcode-stdio-1.0
-    frameworks: Accelerate
-    extra-libraries: cblas
+    extra-libraries: blas
     ghc-options: -Wall -Werror -O2

--- a/test/Bench.hs
+++ b/test/Bench.hs
@@ -28,7 +28,7 @@ benchmarks :: V.Vector Float -> V.Vector Float
 benchmarks u v us vs = [ bgroup "sdot"
    [ bench "naive" $ nf naive (u,v)
    , bench "native" $ nf native (n,u,v)
-   , bench "cblas" $ nf cblas (n,us,vs)
+   , bench "cblas" $ nfIO $ cblas (n,us,vs)
    ]
    ]
    where

--- a/test/Main.hs
+++ b/test/Main.hs
@@ -59,8 +59,8 @@ dotTest testname func genInc = testProperty testname $
        withArray (V.toList u) $ \ us ->
        withArray (V.toList v) $ \ vs -> do
            -- compute the expected and observed values
-           let expected = OSX.sdot n us incx vs incy
-               observed = func n u incx v incy
+           expected <- OSX.sdot n us incx vs incy
+           let observed = func n u incx v incy
            runTest expected observed
       where
       runTest expected observed =

--- a/test/OSX.hs
+++ b/test/OSX.hs
@@ -4,6 +4,18 @@
 module OSX(sdot) where
 
 import Foreign.Ptr
+import Foreign.Marshal.Alloc
+import Foreign.Storable
 
-foreign import ccall "cblas_sdot"
-   sdot :: Int -> Ptr Float -> Int -> Ptr Float -> Int ->  Float
+foreign import ccall "sdot_"
+   sdot_foreign :: Ptr Int -> Ptr Float -> Ptr Int -> Ptr Float -> Ptr Int -> IO Float
+
+sdot :: Int -> Ptr Float -> Int -> Ptr Float -> Int -> IO Float
+sdot n px incx py incy =
+    alloca $ \ pn ->
+    alloca $ \ pincx ->
+    alloca $ \ pincy -> do
+        poke pn n
+        poke pincx incx
+        poke pincy incy
+        sdot_foreign pn px pincx py pincy


### PR DESCRIPTION
Implementing this change required switching from the accelerate framework CBLAS library to a platform neutral BLAS library for benchmarks and tests.   I have chosen to use the FORTRAN BLAS library from [netlib](http://www.netlib.org/blas/).   